### PR TITLE
Fixed build issue due to missing comma (and other minor changes)

### DIFF
--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -1,6 +1,7 @@
 name: Build and deploy Jekyll site to GitHub Pages
 
 on:
+  workflow_dispatch:
   push:
     branches:
       - main

--- a/.github/workflows/github-pages.yml
+++ b/.github/workflows/github-pages.yml
@@ -14,5 +14,5 @@ jobs:
 
     - uses: helaili/jekyll-action@v2
       with:
-        token: ${{ secrets.JEKYLL_PAT }}
+        token: ${{ secrets.GITHUB_TOKEN }}
         target_branch: 'gh-pages'

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -52,7 +52,7 @@ abbr    = {prj}
   pages   = {0--16},
   title   = {{The nanometer limits of ballistic and diffusive hot-hole mediated nonlocal molecular manipulation}},
   year    = {2019}
-  abbr    = {iop:nano}
+  abbr    = {nanotechnology}
 } 
  
  
@@ -163,7 +163,7 @@ abbr    = {prj}
   title   = {{Molecular and atomic manipulation mediated by electronic excitation of the underlying Si(111)-7x7 surface}},
   volume  = {28},
   year    = {2017},
-  abbr    = {iop:nano}
+  abbr    = {nanotechnology}
 } 
  
  

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -1,13 +1,13 @@
 @article{Machnev2021,
-author = {Machnev, Andrey A. and Pushkarev, Anatoly P. and Tonkaev, Pavel and Noskov, Roman E. and Rusimova, Kristina R. and Mosley, Peter J. and Makarov, Sergey V. and Ginzburg, Pavel B. and Shishkin, Ivan I.},
-doi = {10.1364/PRJ.422640},
-journal = {Photonics Research},
-number = {8},
-pages = {1462},
-title = {{Modifying light–matter interactions with perovskite nanocrystals inside antiresonant photonic crystal fiber}},
-volume = {9},
-year = {2021},
-abbr    = {prj}
+  author  = {Machnev, Andrey A. and Pushkarev, Anatoly P. and Tonkaev, Pavel and Noskov, Roman E. and Rusimova, Kristina R. and Mosley, Peter J. and Makarov, Sergey V. and Ginzburg, Pavel B. and Shishkin, Ivan I.},
+  doi     = {10.1364/PRJ.422640},
+  journal = {Photonics Research},
+  number  = {8},
+  pages   = {1462},
+  title   = {{Modifying light–matter interactions with perovskite nanocrystals inside antiresonant photonic crystal fiber}},
+  volume  = {9},
+  year    = {2021},
+  abbr    = {prj}
 }
 
 
@@ -51,7 +51,7 @@ abbr    = {prj}
   journal = {Nanotechnology},
   pages   = {0--16},
   title   = {{The nanometer limits of ballistic and diffusive hot-hole mediated nonlocal molecular manipulation}},
-  year    = {2019}
+  year    = {2019},
   abbr    = {iop:nano}
 } 
  
@@ -140,7 +140,7 @@ abbr    = {prj}
   pages     = {SF1K.7},
   title     = {{Low-frequency suppression of classical laser fluctuations using hollow-core fibre}},
   year      = {2018},
-  abbr    = {cleo}
+  abbr      = {cleo}
 } 
  
  
@@ -176,7 +176,7 @@ abbr    = {prj}
   title     = {{Initiating and imaging the coherent surface dynamics of charge carriers in real space}},
   volume    = {7},
   year      = {2016},
-  abbr    = {natcomm}
+  abbr      = {natcomm}
 } 
  
 @article{Lock2015a,

--- a/_bibliography/papers.bib
+++ b/_bibliography/papers.bib
@@ -52,7 +52,7 @@ abbr    = {prj}
   pages   = {0--16},
   title   = {{The nanometer limits of ballistic and diffusive hot-hole mediated nonlocal molecular manipulation}},
   year    = {2019}
-  abbr    = {nanotechnology}
+  abbr    = {iop:nano}
 } 
  
  
@@ -163,7 +163,7 @@ abbr    = {prj}
   title   = {{Molecular and atomic manipulation mediated by electronic excitation of the underlying Si(111)-7x7 surface}},
   volume  = {28},
   year    = {2017},
-  abbr    = {nanotechnology}
+  abbr    = {iop:nano}
 } 
  
  


### PR DESCRIPTION
If you look in the build logs, the red error bit:
`Liquid Exception: Failed to parse BibTeX on value "abbr" (NAME) [#<BibTeX::Bibliography data=[4]>, "@", #<BibTeX::Entry >, {:author=>["Etheridge, Henry G and Rusimova, Kristina R. and Sloan, Peter A"], :doi=>["10.1088/1361-6528/ab5d7c"], :journal=>["Nanotechnology"], :pages=>["0--16"], :title=>["{The nanometer limits of ballistic and diffusive hot-hole mediated nonlocal molecular manipulation}"], :year=>["2019"]}] in _pages/publications.md`


So it seems like the “abbr” value of the Etheridge paper is causing issues.

Looking at the bibliography, the issue is a missing comma at the end of the previous line. I’ve added this back in.

## Other unrelated changes:
* Enabled manual builds (useful for debugging)
* Use the default GitHub access token
