### PR TITLE
Updated years range

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -2,13 +2,12 @@
 layout: page
 permalink: /publications/
 title: Publications
-years: [1956, 1950, 1935, 1905]
 nav: true
 ---
 
 <div class="publications">
 
-{% for y in (2017..2020) reversed %}
+{% for y in (2017..2022) reversed %}
   <h2 class="year">{{y}}</h2>
   {% bibliography -f papers -q @*[year={{y}}]* %}
 {% endfor %}


### PR DESCRIPTION
See "files changed" tab.

The bibliography page iterates over a range of years to do the posh rendering with the years on the right hand side.

Annoyingly this means that (in its current implementation) we need to update the range every year.

There might be a way around this but I don't have one to hand right now.