### PR TITLE
Add dynamic year groups for bibliography

### DIFF
--- a/_pages/publications.md
+++ b/_pages/publications.md
@@ -6,10 +6,22 @@ nav: true
 ---
 
 <div class="publications">
+<!-- Get the current year as an integer -->
+{% assign thisyear = site.time | date: '%Y' | to_integer %}
+<!-- Loop from 2017 to current year -->
+{% for y in (2017..thisyear) reversed %}
 
-{% for y in (2017..2022) reversed %}
-  <h2 class="year">{{y}}</h2>
-  {% bibliography -f papers -q @*[year={{y}}]* %}
+  <!-- Get number of citations for this year in the loop -->
+  <!-- Gross workaround for https://github.com/inukshuk/jekyll-scholar/issues/310> -->
+  {%- capture citecount -%}
+  {% bibliography_count -f papers -q @*[year={{y}}]* %}
+  {%- endcapture -%}
+
+  <!-- Only show citations for this year in the loop if any exist -->
+  {% if {{citecount}} != "0"  %}
+    <h2 class="year">{{y}}</h2>
+    {% bibliography -f papers -q @*[year={{y}}]* %}
+  {% endif %}
 {% endfor %}
 
 </div>


### PR DESCRIPTION
Updates the publications page to iterate from 2017 to the current year.

Also adds logic to only include a year section is the number of citations is greater than zero.